### PR TITLE
fix: use session.summarize() API instead of TUI command

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -310,15 +310,8 @@ EXAMPLES:
                 })
                 
                 // Trigger compaction directly via API (more reliable than TUI command)
-                // Uses current session's provider/model automatically
                 await ctx.client.session.summarize({
-                  path: { id: toolCtx.sessionID },
-                  body: {
-                    // Defaults to Anthropic's latest Claude model
-                    // OpenCode will use session's actual provider/model if available
-                    providerID: "anthropic",
-                    modelID: "claude-3-5-sonnet-20241022"
-                  }
+                  path: { id: toolCtx.sessionID }
                 })
                 
                 // Message stored in tool.execute.before will be sent via session.idle


### PR DESCRIPTION
## Summary

- Replace unreliable `tui.executeCommand()` with direct `session.summarize()` API call
- Remove hardcoded model parameters (SDK says body is optional)

## Changes

### Fix: Direct API Call for Compaction
The TUI command queue-based system can fail silently. Direct API calls are more reliable.

**Before:**
```typescript
await ctx.client.tui.executeCommand({ 
  body: { command: "session_compact" }
})
```

**After:**
```typescript
await ctx.client.session.summarize({
  path: { id: toolCtx.sessionID }
})
```

### Refactor: Remove Hardcoded Models
The SDK type signature shows `body?` is optional, so we don't need to hardcode:
- ~~`providerID: "anthropic"`~~
- ~~`modelID: "claude-3-5-sonnet-20241022"`~~

OpenCode's server will determine the appropriate model automatically.

## Testing

Compact mode now triggers compaction reliably without hardcoding provider/model assumptions.