### PR TITLE
fix: use session.summarize() API for reliable compaction

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -310,15 +310,8 @@ EXAMPLES:
                 })
                 
                 // Trigger compaction directly via API (more reliable than TUI command)
-                // Uses current session's provider/model automatically
                 await ctx.client.session.summarize({
-                  path: { id: toolCtx.sessionID },
-                  body: {
-                    // Defaults to Anthropic's latest Claude model
-                    // OpenCode will use session's actual provider/model if available
-                    providerID: "anthropic",
-                    modelID: "claude-3-5-sonnet-20241022"
-                  }
+                  path: { id: toolCtx.sessionID }
                 })
                 
                 // Message stored in tool.execute.before will be sent via session.idle


### PR DESCRIPTION
## Summary

Replace unreliable `tui.executeCommand()` with direct `session.summarize()` API call and remove hardcoded model parameters.

## Changes

### 1. Direct API Call for Compaction
The TUI command queue-based system can fail silently. Direct API calls are more reliable.

**Before:**
```typescript
await ctx.client.tui.executeCommand({ 
  body: { command: "session_compact" }
})
```

**After:**
```typescript
await ctx.client.session.summarize({
  path: { id: toolCtx.sessionID }
})
```

### 2. Remove Hardcoded Models
The SDK type signature shows `body?` is optional, so we don't need to hardcode `providerID` and `modelID`. OpenCode's server determines the appropriate model automatically.

## Impact

Compact mode now triggers compaction reliably without hardcoding provider/model assumptions.